### PR TITLE
feat: display single timer

### DIFF
--- a/termtimer.c
+++ b/termtimer.c
@@ -22,11 +22,15 @@ int main(int argc, char **argv) {
         int minutes = (remaining_seconds % 3600) / 60;
         int seconds = remaining_seconds % 60;
 
-        printf("%02d:%02d:%02d\n", hours, minutes, seconds);
+        printf("\r");
+        printf("%02d:%02d:%02d", hours, minutes, seconds);
+        fflush(stdout);
 
         sleep(1);
         remaining_seconds--;
     }
+
+    printf("\n");
 
     return 0;
 }


### PR DESCRIPTION
Displays a single timer rather than successive prints on a new line. 

- `\r` moves the cursor to the beginning of the current line
- `fflush(stdout)` flushes the output buffer to show the timer immediately